### PR TITLE
Implement all gameplay refinements and fixes

### DIFF
--- a/audio.js
+++ b/audio.js
@@ -264,18 +264,18 @@ let currentMusic = null;
 let musicVolume = 0.3;
 
 const musicTracks = {
-  menu: ['music/00_Main_Menu.mp3'],
+  menu: ['mnt/project/music/00_Main_Menu.mp3'],
   levels1to5: [
-    'music/0101_Levels_1-4.mp3',
-    'music/0102_Levels_1-4.mp3',
-    'music/0103_Levels_1-4.mp3',
-    'music/0104_Levels_1-4.mp3'
+    'mnt/project/music/0101_Levels_1-4.mp3',
+    'mnt/project/music/0102_Levels_1-4.mp3',
+    'mnt/project/music/0103_Levels_1-4.mp3',
+    'mnt/project/music/0104_Levels_1-4.mp3'
   ],
   levels6to10: [
-    'music/0201_Levels_6-9.mp3',
-    'music/0202_Levels_6-9.mp3',
-    'music/0203_Levels_6-9.mp3',
-    'music/0204_Levels_6-9.mp3'
+    'mnt/project/music/0201_Levels_6-9.mp3',
+    'mnt/project/music/0202_Levels_6-9.mp3',
+    'mnt/project/music/0203_Levels_6-9.mp3',
+    'mnt/project/music/0204_Levels_6-9.mp3'
   ]
 };
 

--- a/enemies.js
+++ b/enemies.js
@@ -31,10 +31,10 @@ function parsePattern(strings) {
 
 // ── Enemy type stats ───────────────────────────────────────
 const ENEMY_DEFS = {
-  basic: { pattern: parsePattern(PATTERNS.basic), voxelSize: 0.24, baseHp: 30, baseSpeed: 1.5, color: 0x00ff88, depth: 1, scoreValue: 10, hitboxRadius: 0.5 },
-  fast:  { pattern: parsePattern(PATTERNS.fast),  voxelSize: 0.2,  baseHp: 15, baseSpeed: 3.0, color: 0xffff00, depth: 1, scoreValue: 15, hitboxRadius: 0.4 },
-  tank:  { pattern: parsePattern(PATTERNS.tank),  voxelSize: 0.3,  baseHp: 80, baseSpeed: 0.8, color: 0x4488ff, depth: 1, scoreValue: 25, hitboxRadius: 0.7 },
-  swarm: { pattern: parsePattern(PATTERNS.swarm), voxelSize: 0.16, baseHp: 10, baseSpeed: 3.5, color: 0xff8800, depth: 1, scoreValue: 5, hitboxRadius: 0.3 },
+  basic: { pattern: parsePattern(PATTERNS.basic), voxelSize: 0.29, baseHp: 30, baseSpeed: 1.5, color: 0x00ff88, depth: 1, scoreValue: 10, hitboxRadius: 0.6 },
+  fast:  { pattern: parsePattern(PATTERNS.fast),  voxelSize: 0.24, baseHp: 15, baseSpeed: 3.0, color: 0xffff00, depth: 1, scoreValue: 15, hitboxRadius: 0.48 },
+  tank:  { pattern: parsePattern(PATTERNS.tank),  voxelSize: 0.36, baseHp: 80, baseSpeed: 0.8, color: 0x4488ff, depth: 1, scoreValue: 25, hitboxRadius: 0.84 },
+  swarm: { pattern: parsePattern(PATTERNS.swarm), voxelSize: 0.19, baseHp: 10, baseSpeed: 3.5, color: 0xff8800, depth: 1, scoreValue: 5, hitboxRadius: 0.36 },
 };
 
 // ── Module state ───────────────────────────────────────────
@@ -351,9 +351,9 @@ export function getEnemies() {
 /**
  * Get a random spawn position in a 100° cone in front of the player.
  */
-export function getSpawnPosition(airSpawns) {
+export function getSpawnPosition(airSpawns, verticalAngle = 0) {
   const angle    = (Math.random() - 0.5) * (100 * Math.PI / 180);
-  const distance = 18 + Math.random() * 7;
+  const distance = 14.4 + Math.random() * 5.6;  // 20% shorter (was 18-25, now 14.4-20)
 
   const x = Math.sin(angle) * distance;
   const z = -Math.cos(angle) * distance;
@@ -361,6 +361,13 @@ export function getSpawnPosition(airSpawns) {
 
   if (airSpawns) {
     y = 0.5 + Math.random() * 2.5;
+  }
+
+  // Apply vertical angle for difficulty progression
+  if (verticalAngle > 0) {
+    const vertRad = verticalAngle * Math.PI / 180;
+    const baseY = y;
+    y = baseY + Math.sin(vertRad) * distance * Math.random();
   }
 
   return new THREE.Vector3(x, y, z);


### PR DESCRIPTION
Major improvements:
- Fix text billboarding: Convert all sprites to PlaneGeometry to prevent rotation with head
- Increase enemy sizes by 20% (voxelSize *= 1.2)
- Reduce spawn distance by 20% (14.4-20m instead of 18-25m)
- Add vertical spawn angles: 20° at level 6+, 40° at 11+, 60° at 16+
- Change buckshot to random 7.5° cone spread (both yaw and pitch)
- Optimize damage numbers: reduce lifetime to 500ms, remove fade
- Make upgrade text smaller and consistent (fontSize 36/24 instead of 52/32)
- Fix music paths to mnt/project/music/
- Increase bullet-time trigger distance from 0.5m to 2.0m
- Fix hit flash to use rawDt so it works during bullet-time

VR-specific fixes:
- Camera shake doesn't work in VR (headset controls position)
- Red flash overlay serves as damage feedback in VR
- All UI now uses non-billboarding meshes for fixed world-space positioning