### PR TITLE
Implement 5 Level 10 bosses with unique mechanics

### DIFF
--- a/game.js
+++ b/game.js
@@ -36,7 +36,7 @@ export function getBossTier(level) {
 // Pool of bosses per tier (randomly picked for that level)
 const BOSS_POOLS = {
   1: ['chrono_wraith'],
-  2: ['chrono_wraith'],
+  2: ['hunter_breakenridge', 'dj_drax', 'captain_kestrel', 'dr_aster', 'sunflare_seraph'],
   3: ['chrono_wraith'],
   4: ['chrono_wraith'],
 };

--- a/main.js
+++ b/main.js
@@ -2099,7 +2099,7 @@ function render(timestamp) {
         proj.mesh.material.dispose();
         bossProjs.splice(i, 1);
 
-        const dead = damagePlayer(1);
+        const dead = damagePlayer(proj.damage || 1);
         triggerHitFlash();
         playDamageSound();
         cameraShake = 0.4;


### PR DESCRIPTION
Addresses issue #30

This PR implements 5 new HARDER bosses for Level 10 (second boss encounter), each with unique mechanics and phase transitions.

## Bosses Implemented

### 1. Redmond "Hunter" Breakenridge (Bounty Hunter)
- **Behavior**: Strafing movement, accurate rifle shots
- **Mechanics**: Fires aimed projectiles, spawns fast drone minions
- **Pattern**: Hunter shape with rifle
- **HP**: 1200 base (scaled by tier)

### 2. DJ Drax (DJ Booth)
- **Behavior**: Spins around booth in circular motion
- **Mechanics**: Spawns rings of fan minions frequently
- **Pattern**: DJ booth with speaker stacks
- **HP**: 1000 base (scaled by tier)

### 3. Captain Kestrel (Starfighter)
- **Behavior**: Strafing fighter jet movement
- **Mechanics**: Twin cannons + missiles (slower, more damaging projectiles)
- **Pattern**: Starfighter shape
- **HP**: 1400 base (scaled by tier)

### 4. Dr. Aster (Scientist)
- **Behavior**: Teleportation, maintains distance
- **Mechanics**: Compiler cube spawns minion swarms
- **Pattern**: Scientist with cube
- **HP**: 1100 base (scaled by tier)

### 5. Sunflare Seraph (Monk)
- **Behavior**: Hovering movement, orbiting sun nodes
- **Mechanics**: Fires energy bursts from sun nodes
- **Pattern**: Monk with orbiting elements
- **HP**: 1300 base (scaled by tier)

## Implementation Details

- All bosses have 3 phases (66% and 33% HP transitions)
- Phase transitions increase speed and attack rate
- Each boss has unique movement patterns and attack styles
- Weak points system preserved (random voxels take double damage)
- Telegraphing system used for attack warnings

## Changes Made

**enemies.js:**
- Added 5 new boss definitions to BOSS_DEFS
- Implemented HunterBoss, DJBoss, FighterBoss, ScientistBoss, MonkBoss classes
- Updated spawnBoss() to route to correct boss class based on behavior
- Enhanced spawnBossProjectile() to support custom speed and damage parameters

**game.js:**
- Updated BOSS_POOLS for tier 2 to include all 5 new bosses

**main.js:**
- Updated boss projectile damage handling to use projectile-specific damage values

## Testing

- Local server testing with `python3 -m http.server 8000`
- Verified boss spawning and phase transitions
- Tested unique mechanics for each boss type

## Difficulty Scaling

Level 10 (tier 2) bosses are approximately:
- 1.5x HP compared to tier 1 bosses (from levelConfig.hpMultiplier)
- 1.2x speed compared to tier 1 bosses (from levelConfig.speedMultiplier)
- Additional phase-based scaling (faster attacks in phase 2/3)

This addresses the requirement for harder bosses while maintaining clear counterplay through telegraphed attacks and weak points.