### PR TITLE
fix: Add missing playBossTeleportDisappear function

### DIFF
--- a/audio.js
+++ b/audio.js
@@ -438,6 +438,27 @@ export function playBossSpawn() {
   });
 }
 
+// ── Boss teleport disappear ─────────────────────────────────
+export function playBossTeleportDisappear() {
+  const ctx = getAudioContext();
+  const t = ctx.currentTime;
+
+  // Dematerialization sound - reverse of reappear
+  const osc = ctx.createOscillator();
+  const gain = ctx.createGain();
+  osc.type = 'sawtooth';
+  osc.frequency.setValueAtTime(200, t);
+  osc.frequency.exponentialRampToValueAtTime(800, t + 0.2);
+
+  gain.gain.setValueAtTime(0.2, t);
+  gain.gain.exponentialRampToValueAtTime(0.01, t + 0.2);
+
+  osc.connect(gain);
+  gain.connect(ctx.destination);
+  osc.start(t);
+  osc.stop(t + 0.2);
+}
+
 // ── Boss teleport reappear ─────────────────────────────────
 export function playBossTeleportReappear() {
   const ctx = getAudioContext();


### PR DESCRIPTION
Fixes #78

## Problem
The game was failing to load due to a missing export: `playBossTeleportDisappear` was imported by main.js but not defined in audio.js.

## Solution
Added the missing `playBossTeleportDisappear` function to audio.js. This function creates a dematerialization sound (reverse of the reappear sound) when the boss teleports away.

## Testing
- All JavaScript files pass syntax validation
- Function signature matches the import in main.js
- Sound effect is consistent with other boss audio

## Files Changed
- audio.js: Added `playBossTeleportDisappear` function