### PR TITLE
fix: Filter weapon-specific upgrades for all weapon types (#87)

### DIFF
--- a/main.js
+++ b/main.js
@@ -1139,8 +1139,12 @@ function debugJumpToLevel(targetLevel) {
       const special = getRandomSpecialUpgrades(1)[0];
       if (special) addUpgrade(special.id, hand(lvl, 0));
     } else {
-      const upgrades = getRandomUpgrades(3);
-      upgrades.forEach((u, idx) => addUpgrade(u.id, hand(lvl, idx)));
+      // For each upgrade, determine which hand it goes to and filter accordingly
+      for (let idx = 0; idx < 3; idx++) {
+        const h = hand(lvl, idx);
+        const upgrade = getRandomUpgrades(1, [], game.upgrades[h])[0];
+        if (upgrade) addUpgrade(upgrade.id, h);
+      }
     }
   }
 
@@ -1221,7 +1225,7 @@ function showUpgradeScreen() {
     console.log(`[game] Both hands have ${leftShotType}, excluding from upgrade pool`);
   }
 
-  pendingUpgrades = game.justBossKill ? getRandomSpecialUpgrades(3) : getRandomUpgrades(3, excludeIds);
+  pendingUpgrades = game.justBossKill ? getRandomSpecialUpgrades(3) : getRandomUpgrades(3, excludeIds, game.upgrades[upgradeHand]);
   showUpgradeCards(pendingUpgrades, camera.position, upgradeHand);
   if (game.justBossKill) game.justBossKill = false;
   upgradeSelectionCooldown = 1.5; // prevent instant selection
@@ -1965,7 +1969,8 @@ function selectUpgrade(controller) {
 function selectUpgradeAt(index) {
   if (upgradeSelectionCooldown > 0) return;
 
-  const upgrades = getRandomUpgrades(3);
+  // Use the already-shown pending upgrades instead of regenerating
+  const upgrades = pendingUpgrades;
   if (index >= 0 && index < upgrades.length) {
     const upgrade = upgrades[index];
     // Randomly assign to left or right hand


### PR DESCRIPTION
## Problem
Players were being offered weapon-specific upgrades for weapons they didn't currently have equipped. For example, being offered buckshot upgrades when you don't have a buckshot weapon.

There was a previous fix for this (commit 53efbd0) but it wasn't applied correctly during merge, so the filtering logic was missing from the current codebase.

## Solution
Implemented comprehensive weapon-specific upgrade filtering:

1. **Added WEAPON_TYPES enum** - Defines all weapon types (STANDARD, BUCKSHOT, LIGHTNING, CHARGE, PLASMA, SEEKER)

2. **Added getWeaponType() function** - Determines the player's current weapon type from their upgrades

3. **Added requiresWeapon property** to all weapon-specific upgrades:
   - Triple Shot (STANDARD)
   - Focused Frenzy, Buckshot Gentlemen, Duck Hunt (BUCKSHOT)
   - It's Electric!, Tesla Coil (LIGHTNING)
   - Quick Charge, Excess Heat, Death Ray (CHARGE)
   - Hold It Together (PLASMA)
   - Gimme Gimme More (SEEKER)

4. **Updated getRandomUpgrades()** - Now filters upgrades based on the player's current weapon type

5. **Updated all call sites** - Pass current hand upgrades to getRandomUpgrades()

6. **Fixed selectUpgradeAt()** - Now uses the already-shown pendingUpgrades instead of regenerating (which would have incorrect filtering)

7. **Updated debugJumpToLevel()** - Respects weapon-specific filters when auto-generating upgrades

## Testing
Players should now only see upgrades for the weapon they have equipped:
- No plasma upgrades without plasma weapon
- No buckshot upgrades without buckshot
- No seeker upgrades without seeker
- No lightning upgrades without lightning
- No charge upgrades without charge cannon
- Universal upgrades always available

Addresses issue #87