### PR TITLE
feat: Add alt fire tutorial system with improved visuals and HUD (#89)

### DIFF
--- a/game.js
+++ b/game.js
@@ -16,6 +16,7 @@ export const State = {
   REGIONAL_SCORES: 'regional_scores',
   READY_SCREEN: 'ready_screen',
   LEVEL_INTRO: 'level_intro',
+  ALT_TUTORIAL: 'alt_tutorial',
 };
 
 // ── Enemy types available per level ────────────────────────
@@ -89,6 +90,7 @@ export const game = {
   altWeapon: { left: null, right: null },  // ALT weapon per hand (unlocked via upgrades)
   altCooldowns: { left: 0, right: 0 },  // ALT weapon cooldowns (ms)
   upgrades: { left: {}, right: {} },  // Upgrades per hand
+  altFireTutorialSeen: false,  // Track if player has seen alt fire tutorial
   mainWeaponLocked: { left: false, right: false },  // Whether MAIN weapon is locked (chosen)
   
   stateTimer: 0,

--- a/main.js
+++ b/main.js
@@ -7,7 +7,7 @@ import * as THREE from 'three';
 import { VRButton } from 'three/addons/webxr/VRButton.js';
 
 import { State, game, resetGame, getLevelConfig, getBossTier, getRandomBossIdForLevel, addScore, getComboMultiplier, damagePlayer, addUpgrade, LEVELS } from './game.js';
-import { getRandomUpgrades, getRandomSpecialUpgrades, getRandomUpgradeExcluding, getUpgradeDef, getWeaponStats } from './upgrades.js';
+import { getRandomUpgrades, getRandomSpecialUpgrades, getRandomUpgradeExcluding, getUpgradeDef, getWeaponStats, isAltWeaponUpgrade } from './upgrades.js';
 import {
   playShoothSound, playHitSound, playExplosionSound, playDamageSound,
   playFastEnemySpawn, playSwarmEnemySpawn, playBasicEnemySpawn, playTankEnemySpawn,
@@ -37,7 +37,8 @@ import {
   showCountrySelect, hideCountrySelect, getCountrySelectHit,
   showDebugJumpScreen, getDebugJumpHit,
   showLevelIntro, updateLevelIntro, hideLevelIntro,
-  showKillsRemainingAlert, updateKillsAlert, hideKillsAlert, isKillsAlertActive
+  showKillsRemainingAlert, updateKillsAlert, hideKillsAlert, isKillsAlertActive,
+  showAltFireTutorial, hideAltFireTutorial
 } from './hud.js';
 import {
   submitScore, fetchTopScores, fetchScoresByCountry, fetchScoresByContinent,
@@ -779,6 +780,8 @@ function onTriggerPress(controller, index) {
     handleCountrySelectTrigger(controller);
   } else if (st === State.READY_SCREEN) {
     handleReadyScreenTrigger(controller);
+  } else if (st === State.ALT_TUTORIAL) {
+    handleAltFireTutorialTrigger(controller);
   }
 }
 
@@ -805,6 +808,8 @@ function handleDesktopClick() {
     handleDesktopCountrySelectClick();
   } else if (st === State.READY_SCREEN) {
     handleDesktopReadyScreenClick();
+  } else if (st === State.ALT_TUTORIAL) {
+    handleDesktopAltFireTutorialClick();
   }
 }
 
@@ -943,6 +948,12 @@ function handleDesktopReadyScreenClick() {
   playMenuClick();
   hideUpgradeCards();
   game.state = State.PLAYING;
+}
+
+function handleDesktopAltFireTutorialClick() {
+  playMenuClick();
+  hideAltFireTutorial();
+  advanceLevelAfterUpgrade();
 }
 
 function handleTitleTrigger(controller) {
@@ -1179,6 +1190,13 @@ function handleReadyScreenTrigger(controller) {
   }
 }
 
+function handleAltFireTutorialTrigger(controller) {
+  // Dismiss tutorial on any trigger press
+  playMenuClick();
+  hideAltFireTutorial();
+  advanceLevelAfterUpgrade();
+}
+
 function startGame() {
   console.log('[game] Starting new game');
   hideTitle();
@@ -1282,6 +1300,24 @@ function selectUpgradeAndAdvance(upgrade, hand) {
   addUpgrade(upgrade.id, hand);
   playUpgradeSound();
   hideUpgradeCards();
+
+  // Handle alt weapon unlock
+  if (isAltWeaponUpgrade(upgrade.id)) {
+    // Map alt weapon upgrade ID to alt weapon ID
+    const altWeaponId = upgrade.id.replace('alt_', '');
+    game.altWeapon[hand] = altWeaponId;
+    console.log(`[game] Unlocked alt weapon: ${altWeaponId} for ${hand} hand`);
+
+    // Show tutorial on first alt weapon
+    if (!game.altFireTutorialSeen) {
+      game.altFireTutorialSeen = true;
+      game.state = State.ALT_TUTORIAL;
+      showAltFireTutorial();
+      console.log('[game] Showing alt fire tutorial for first alt weapon');
+      return;
+    }
+  }
+
   advanceLevelAfterUpgrade();
 }
 

--- a/upgrades.js
+++ b/upgrades.js
@@ -33,7 +33,13 @@ export const UPGRADE_POOL = [
   { id: 'hollow_point', name: 'Hollow-Point', desc: '+15% damage', color: '#ff8888' },
   { id: 'nova_tip', name: 'Nova Tip', desc: 'Every 12th shot detonates AoE (60 damage)', color: '#ff44ff' },
   { id: 'siphon', name: 'Siphon', desc: 'Every 15 kills reduces ALT cooldown by 25%', color: '#aa88ff' },
-  
+
+  // Alt weapons (unlocked as upgrades)
+  { id: 'alt_shield', name: 'SHIELD', desc: 'Blocks enemy projectiles', color: '#4488ff', type: 'alt', sideGradeNote: 'ALT FIRE ABILITY' },
+  { id: 'alt_grenade', name: 'GRENADE', desc: 'Throwable explosive', color: '#ff4444', type: 'alt', sideGradeNote: 'ALT FIRE ABILITY' },
+  { id: 'alt_mine', name: 'MINE', desc: 'Placeable explosive trap', color: '#ffaa00', type: 'alt', sideGradeNote: 'ALT FIRE ABILITY' },
+  { id: 'alt_drone', name: 'DRONE', desc: 'Auto-targeting helper', color: '#88ff88', type: 'alt', sideGradeNote: 'ALT FIRE ABILITY' },
+
   // Standard Blaster specific
   { id: 'triple_shot', name: 'Triple Shot', desc: 'Fire two extra projectiles', color: '#00ffff' },
   
@@ -121,6 +127,14 @@ export function getRandomUpgradeExcluding(excludeIds = []) {
 /** Look up an upgrade definition by id */
 export function getUpgradeDef(id) {
   return UPGRADE_POOL.find(u => u.id === id) || null;
+}
+
+/**
+ * Check if an upgrade is an alt weapon type
+ */
+export function isAltWeaponUpgrade(upgradeId) {
+  const def = getUpgradeDef(upgradeId);
+  return def && def.type === 'alt';
 }
 
 /**


### PR DESCRIPTION
## Summary
Implemented a comprehensive alt fire tutorial system with improved visual distinction for alt weapon cards and real-time HUD cooldown indicators.

## Visual Improvements
- **Alt weapon cards** now stand out with:
  - Distinctive cyan border with inner glow
  - Different background color (blue) vs purple for regular upgrades
  - Star icon with wireframe glow (vs octahedron for regular upgrades)
  - 'ALT FIRE ABILITY' label in cyan
- Clear visual separation from regular upgrades

## Tutorial System
When player gets their first alt weapon:
- **Game pauses** and shows modal popup
- **Title**: "NEW ABILITY UNLOCKED!"
- **Instructions**: "To use abilities, press the lower trigger"
- **Explanation**: "Abilities have a cooldown, shown on the HUD"
- **Controller diagram**: Custom Quest 3 controller with highlighted lower trigger (middle finger)
  - Upper trigger (index finger): MAIN FIRE (gray)
  - Lower trigger (middle finger): ALT ABILITY (cyan, glowing)
- Dismisses on trigger press (VR or desktop)
- Tracks if player has seen tutorial (doesn't show again)

## HUD Improvements
- **Alt cooldown indicators** at bottom corners of HUD:
  - Left and right indicators for each hand
  - **Ready**: Shows "ALT READY" with pulsing green glow
  - **On cooldown**: Shows countdown timer (e.g., "ALT 3s") in red
  - Automatically hides when no alt weapon equipped
- Real-time updates during gameplay

## Alt Weapon Unlock
- Added 4 alt weapons to upgrade pool:
  - **SHIELD** (blue): Blocks enemy projectiles
  - **GRENADE** (red): Throwable explosive
  - **MINE** (orange): Placeable explosive trap
  - **DRONE** (green): Auto-targeting helper
- Automatically unlocks alt weapon when upgrade selected
- Maps alt weapon upgrade IDs to ALT_WEAPONS in weapons.js

## Technical Details
- Added `ALT_TUTORIAL` state to game states
- Added `altFireTutorialSeen` flag to track tutorial status
- Added `isAltWeaponUpgrade()` helper function
- Created `showAltFireTutorial()` and `hideAltFireTutorial()` HUD functions
- Created `createControllerDiagram()` for Quest 3 controller visualization
- Added `updateAltCooldownIndicators()` for HUD updates
- Added VR and desktop handlers for tutorial dismissal

## Acceptance Criteria Met
✅ Alt fire cards are visually distinct (cyan border, blue background, star icon)
✅ First-time pickup triggers tutorial popup
✅ Popup shows Quest 3 controller diagram with highlighted lower trigger
✅ Lower trigger is highlighted in cyan with glow effect
✅ HUD shows cooldown state (ready/countdown)
✅ Player understands how to use abilities (clear instructions + diagram)

Addresses issue #89